### PR TITLE
Speed up by searching for properties only once

### DIFF
--- a/lib/chai-as-promised.js
+++ b/lib/chai-as-promised.js
@@ -21,6 +21,40 @@
     var Assertion = chai.Assertion;
     var assert = chai.assert;
 
+    // Find Assertion methods, chainable methods and properties
+    var chaiAsserters = ["fulfilled", "rejected", "broken", "eventually", "become"];
+    var asserterNames = Object.getOwnPropertyNames(Assertion.prototype);
+    var assertionMethods = {};
+    var assertionChainableMethods = {};
+    var assertionProperties = {};
+    asserterNames.forEach(function (asserterName) {
+        // Don't mess with assert
+        if (asserterName === "assert") {
+            return;
+        }
+
+        var propertyDescriptor = Object.getOwnPropertyDescriptor(Assertion.prototype, asserterName);
+
+        if (typeof propertyDescriptor.value === "function") {
+            // Case 1: simple method asserters
+            assertionMethods[asserterName] = propertyDescriptor.value;
+        } else if (typeof propertyDescriptor.get === "function") {
+            // Case 2: property asserters
+            var isChainableMethod = false;
+            try {
+                isChainableMethod = typeof propertyDescriptor.get.call({}) === "function";
+            } catch (e) { }
+
+            if (isChainableMethod) {
+                // Case 2A: chainable methods
+                assertionChainableMethods[asserterName] = propertyDescriptor.get;
+            } else {
+                // Case 2B: pure property case
+                assertionProperties[asserterName] =  propertyDescriptor.get;
+            }
+        }
+    });
+
     function assertIsAboutPromise(assertion) {
         if (typeof assertion._obj.then !== "function") {
             throw new TypeError(utils.inspect(assertion._obj) + " is not a promise!");
@@ -227,10 +261,6 @@
         return transformedPromise;
     };
 
-    function isChaiAsPromisedAsserter(asserterName) {
-        return ["fulfilled", "rejected", "broken", "eventually", "become"].indexOf(asserterName) !== -1;
-    }
-
     function makeAssertionPromiseToDoAsserter(currentAssertionPromise, previousAssertionPromise, doAsserter) {
         var promiseToDoAsserter = currentAssertionPromise.then(function (fulfillmentValue) {
             // The previous assertion promise might have picked up some flags while waiting for fulfillment.
@@ -259,73 +289,54 @@
         };
 
         // 3. Chai asserters, which act upon the promise's fulfillment value.
-        var asserterNames = Object.getOwnPropertyNames(Assertion.prototype);
-        asserterNames.forEach(function (asserterName) {
-            // We already added `notify` and `assert`; don't mess with those.
-            if (asserterName === "notify" || asserterName === "assert") {
-                return;
-            }
+        // Case 1: simple method asserters
+        Object.keys(assertionMethods).forEach(function (asserterName) {
+            var method = assertionMethods[asserterName];
+            utils.addMethod(assertionPromise, asserterName, function () {
+                var args = arguments;
 
-            // Only add asserters for other libraries; poison-pill Chai as Promised ones.
-            if (isChaiAsPromisedAsserter(asserterName)) {
-                utils.addProperty(assertionPromise, asserterName, function () {
-                    throw new Error("Cannot use Chai as Promised asserters more than once in an assertion.");
+                return makeAssertionPromiseToDoAsserter(assertionPromise, baseAssertion, function () {
+                    return method.apply(assertionPromise, args);
                 });
-                return;
-            }
+            });
+        });
 
-            // The asserter will need to be added differently depending on its type. In all cases we use
-            // `makeAssertionPromiseToDoAsserter`, which, given this current `assertionPromise` we are going to
-            // return, plus the `baseAssertion` we are basing it off of, will return a new assertion-promise that
-            // builds off of `assertionPromise` and `baseAssertion` to perform the actual asserter action upon
-            // fulfillment.
-            var propertyDescriptor = Object.getOwnPropertyDescriptor(Assertion.prototype, asserterName);
-
-            if (typeof propertyDescriptor.value === "function") {
-                // Case 1: simple method asserters
-                utils.addMethod(assertionPromise, asserterName, function () {
+        // Case 2: property asserters. These break down into two subcases: chainable methods, and pure
+        // properties. An example of the former is `a`/`an`: `.should.be.an.instanceOf` vs.
+        // `should.be.an("object")`.
+        Object.keys(assertionChainableMethods).forEach(function (asserterName) {
+            var method = assertionChainableMethods[asserterName];
+            utils.addChainableMethod(
+                assertionPromise,
+                asserterName,
+                function () {
                     var args = arguments;
 
                     return makeAssertionPromiseToDoAsserter(assertionPromise, baseAssertion, function () {
-                        return propertyDescriptor.value.apply(assertionPromise, args);
+                        return method.call(method).apply(assertionPromise, args);
                     });
-                });
-            } else if (typeof propertyDescriptor.get === "function") {
-                // Case 2: property asserters. These break down into two subcases: chainable methods, and pure
-                // properties. An example of the former is `a`/`an`: `.should.be.an.instanceOf` vs.
-                // `should.be.an("object")`.
-                var isChainableMethod = false;
-                try {
-                    isChainableMethod = typeof propertyDescriptor.get.call({}) === "function";
-                } catch (e) { }
-
-                if (isChainableMethod) {
-                    // Case 2A: chainable methods. Recreate the chainable method, but operating on the augmented
-                    // promise. We need to copy both the assertion behavior and the chaining behavior, since the
-                    // chaining behavior might for example set flags on the object.
-                    utils.addChainableMethod(
-                        assertionPromise,
-                        asserterName,
-                        function () {
-                            var args = arguments;
-
-                            return makeAssertionPromiseToDoAsserter(assertionPromise, baseAssertion, function () {
-                                return propertyDescriptor.get().apply(assertionPromise, args);
-                            });
-                        },
-                        function () {
-                            return propertyDescriptor.get.call(assertionPromise);
-                        }
-                    );
-                } else {
-                    // Case 2B: pure property case
-                    utils.addProperty(assertionPromise, asserterName, function () {
-                        return makeAssertionPromiseToDoAsserter(assertionPromise, baseAssertion, function () {
-                            return propertyDescriptor.get.call(assertionPromise);
-                        });
-                    });
+                },
+                function () {
+                    return method.call(assertionPromise);
                 }
-            }
+            );
+        });
+
+        // Case 2B: pure property case
+        Object.keys(assertionProperties).forEach(function (asserterName) {
+            var property = assertionProperties[asserterName];
+            utils.addProperty(assertionPromise, asserterName, function () {
+                return makeAssertionPromiseToDoAsserter(assertionPromise, baseAssertion, function () {
+                    return property.call(assertionPromise);
+                });
+            });
+        });
+
+        // Poison-pill Chai as Promised asserters
+        chaiAsserters.forEach(function (asserterName) {
+            utils.addProperty(assertionPromise, asserterName, function () {
+                throw new Error("Cannot use Chai as Promised asserters more than once in an assertion.");
+            });
         });
 
         return assertionPromise;


### PR DESCRIPTION
Profiling revealed that Chai as Promised spends quite some time in descriptor-related methods:

```
 [C++]:
   ticks  total  nonlib   name
   1731    5.0%    5.0%  v8::internal::Marker<v8::internal::IncrementalMarking>::MarkDescriptorArray
   1229    3.6%    3.6%  v8::internal::JSObject::LookupInDescriptor
   1183    3.4%    3.4%  v8::internal::DescriptorArray::BinarySearch
    777    2.3%    2.3%  v8::internal::DescriptorArray::CopyInsert
    480    1.4%    1.4%  v8::internal::DescriptorArray::CopyFrom
```

This code moves the search for properties to the start of the code, so it only executes once. The resulting code still spends a lot of time in MarkDescriptorArray, but it is way faster on the testcase of Issue #14.

On the following stress test of `eventually`, this patch takes only 9s instead of 23s.

``` javascript
var chai = require("chai");
var Q = require("q");
chai.should();
chai.use(require("chai-as-promised"));

var repeats = 1000;
for(var i = 0; i < repeats; i++)
  Q.delay('x', 10).should.eventually.be.a('string').notify(function () {
    if (!--repeats)
      console.log("done");
  });
```

Be aware however, that this implies `chai-as-promised` should be required last in the `chai.use` chain (or `chai.use` should be overridden to retrigger property indexing.) Alternatively, indexing can happen when the first assertion is executed.
