### PR TITLE
Make browser tests work with current versions of 'when' and 'Q'.

### DIFF
--- a/test/browser/libraries/q.coffee
+++ b/test/browser/libraries/q.coffee
@@ -2,6 +2,14 @@ exports.name = "Q"
 
 exports.uri = "https://raw.github.com/kriskowal/q/master/q.js"
 
+# Q.js doesn't work under mocha, because mocha stubs out some
+# node.js globals, making it think it's running in node.
+# Unsetting this makes it work:
+
+exports.shim = """
+  window.process = undefined;
+"""
+
 exports.adapter = """
     global.fulfilledPromise = Q.resolve;
     global.rejectedPromise = Q.reject;

--- a/test/browser/libraries/when.coffee
+++ b/test/browser/libraries/when.coffee
@@ -2,6 +2,15 @@ exports.name = "when.js"
 
 exports.uri = "https://raw.github.com/cujojs/when/master/when.js"
 
+# This shim is described in the when.js readme for use without module loaders.
+exports.shim = """
+    window.define = function(factory) {
+        try{ delete window.define; } catch(e){ window.define = void 0; } // IE
+        window.when = factory();
+    };
+    window.define.amd = {};
+"""
+
 exports.adapter = """
     global.fulfilledPromise = function (value) {
         var deferred = when.defer();

--- a/test/browser/template.html
+++ b/test/browser/template.html
@@ -16,6 +16,7 @@
         mocha.setup("bdd");
     </script>
 
+    <script><%= library.shim %></script>
     <script src="<%= library.uri %>"></script>
     <script><%= library.adapter %></script>
 


### PR DESCRIPTION
When I tried to run the browser tests, I found that they were broken for both "when" and "q".

This fixes problems with both:

"when": Doesn't seem to support being loaded without a module loader, and the current readme suggests including a shim 'define' function, so I have.

"q": Doesn't seem to work under mocha, because mocha stubs out some node.js globals, including "process", and "q" assumes process.nextTick is available when process is defined, which it isn't in the browser. To fix this I unset the "process" global. I think Q and mocha should sort this incompatibility out, but I'm not sure where the real fix belongs.
