### PR TITLE
Add failing property result test.

### DIFF
--- a/test/fulfillmentValues.coffee
+++ b/test/fulfillmentValues.coffee
@@ -117,3 +117,6 @@
             shouldPass -> promise.should.become(foo: "bar")
         describe ".not.become({ foo: 'bar' })", ->
             shouldFail -> promise.should.not.become(foo: "bar")
+
+        describe ".eventually.have.property('foo').that.equals('bar')", ->
+            shouldPass -> promise.should.eventually.have.property('foo').that.equals('bar')


### PR DESCRIPTION
This test fails with expected { foo: 'bar' } to equal 'bar'.  The
property asserter in chai sets the object flag to the property value (in
the single argument form), but the promise adapting wrapper is not picking
up on this.
