### PR TITLE
Chai-as-promised breaks in Browserify since it includes BOM at the start of the file stream

### DIFF
--- a/lib/chai-as-promised.js
+++ b/lib/chai-as-promised.js
@@ -1,4 +1,4 @@
-﻿(function (chaiAsPromised) {
+(function (chaiAsPromised) {
     "use strict";
 
     // Module systems magic dance.


### PR DESCRIPTION
This is actually a problem in Browserify (or some of its dependencies, didn't analyse yet) (see substack/node-browserify#313), which keeps the BOM markers when bundling the stream, however it hasn't been fixed in months, and @substack hasn't commented on that issue himself.

At any rate, I don't think the library uses anything by removing the marker, and by removing it it'll work on Browserify and Testling CI, so...
