### PR TITLE
Add option to not check for pipe functions

### DIFF
--- a/lib/chai-as-promised.js
+++ b/lib/chai-as-promised.js
@@ -25,7 +25,7 @@
         if (typeof assertion._obj.then !== "function") {
             throw new TypeError(utils.inspect(assertion._obj) + " is not a promise!");
         }
-        if (typeof assertion._obj.pipe === "function") {
+        if (chaiAsPromised.dontCheckPipe !== true && typeof assertion._obj.pipe === "function") {
             throw new TypeError("Chai as Promised is incompatible with jQuery's so-called “promises.” Sorry!");
         }
     }


### PR DESCRIPTION
I'm working on a promise/stream hybrid, which has a `pipe()` method. This makes Chai-As-Promised think I returned a jQuery promise.

Added support for explicitly opting out of this check by setting a property on the Chai plugin function.

I'd add tests but I'm already seeing 38 test failures when running `npm test`.
