### PR TITLE
Avoid issues when Assertion's prototype methods don't have an apply method

### DIFF
--- a/lib/chai-as-promised.js
+++ b/lib/chai-as-promised.js
@@ -257,7 +257,7 @@
                 function () {
                     var assertion = this;
                     function originalMethod() {
-                        return propertyDesc.get.call(assertion).apply(assertion, arguments);
+                        return Function.prototype.apply.apply(propertyDesc.get.call(assertion), [assertion].concat(arguments));
                     }
                     doAsserterAsyncAndAddThen(originalMethod, this, arguments);
                 },


### PR DESCRIPTION
For example, I was receiving these errors:

```
TypeError: Object function () {
  var result = method.apply(this, arguments);
  return result === undefined ? this : result;
} has no method 'apply'
```
