### PR TITLE
Add `is.a.promise`

### DIFF
--- a/lib/chai-as-promised.js
+++ b/lib/chai-as-promised.js
@@ -38,9 +38,13 @@
                    typeof thenable.progress === "function" &&
                    typeof thenable.state === "function";
         }
+        
+        function isThenable(asserted){
+            return !!asserted && typeof asserted.then === "function";
+        }
 
         function assertIsAboutPromise(assertion) {
-            if (typeof assertion._obj.then !== "function") {
+            if (! isThenable(assertion._obj)) {
                 throw new TypeError(utils.inspect(assertion._obj) + " is not a thenable.");
             }
             if (isJQueryPromise(assertion._obj)) {
@@ -83,7 +87,7 @@
             // previously derived promises, to chain off of.
             return typeof assertion.then === "function" ? assertion : assertion._obj;
         }
-
+        
         // Grab these first, before we modify `Assertion.prototype`.
 
         var propertyNames = Object.getOwnPropertyNames(Assertion.prototype);
@@ -93,6 +97,13 @@
             propertyDescs[name] = Object.getOwnPropertyDescriptor(Assertion.prototype, name);
         });
 
+        //we can't use `property` since it'll throw a TypeError instead
+        utils.addProperty(Assertion.prototype, 'promise', function(){
+            this.assert(isThenable(this._obj),
+                        "expected #{this} to be a promise",
+                        "expected #{this} not to be a promise");
+        });
+        
         property("fulfilled", function () {
             var that = this;
             var derivedPromise = getBasePromise(that).then(

--- a/test/should-promise-specific.coffee
+++ b/test/should-promise-specific.coffee
@@ -12,11 +12,19 @@ describe "Promise-specific extensions:", =>
                 return done(assertionError)
 
             done()
+            
+    describe "when an object is thenable", =>
+        beforeEach =>
+            promise = then: ->
+        
+        describe ".promise", =>
+            it "should pass", =>
+                promise.should.be.promise
 
     describe "when the promise is fulfilled", =>
         beforeEach =>
             promise = fulfilledPromise()
-
+        
         describe ".fulfilled", =>
             shouldPass => promise.should.be.fulfilled
         describe ".not.fulfilled", =>
@@ -268,7 +276,9 @@ describe "Promise-specific extensions:", =>
                 expect(=> number.should.eventually.equal(5)).to.throw(TypeError, "not a thenable")
             it "should fail for .notify", =>
                 expect(=> number.should.notify(=>)).to.throw(TypeError, "not a thenable")
-
+            it "should fail for .promise", =>
+                expect(=> number.should.be.promise).to.throw(AssertionError, "expected 5 to be a promise");
+                
     describe "Using together with other Chai as Promised asserters", =>
         describe ".fulfilled.and.eventually.equal(42)", =>
             shouldPass => fulfilledPromise(42).should.be.fulfilled.and.eventually.equal(42)


### PR DESCRIPTION
I noticed there's already a `assertIsAboutPromise` function, so I think this should be quite trivial; it would be really handy to be able to do:

``` js
expect(foo).to.be.a.promise;
```

AFAIK that's not possible ATM, right?
