### PR TITLE
Use an alternative to `bind` in `transferPromiseness`

### DIFF
--- a/lib/chai-as-promised.js
+++ b/lib/chai-as-promised.js
@@ -23,7 +23,9 @@
     }
 
     chaiAsPromised.transferPromiseness = function (assertion, promise) {
-        assertion.then = promise.then.bind(promise);
+        assertion.then = function() {
+            return promise.then.apply(promise, arguments);
+        }
     };
 
     function chaiAsPromised(chai, utils) {


### PR DESCRIPTION
A simple call to `apply` with the appropriate context provides the same effect as `bind` with much greater browser compatibility. This fixed my test suite in PhantomJS and will allow chai-as-promised to work [with older browsers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind) too.
