### PR TITLE
Handle additional error-like objects

### DIFF
--- a/lib/chai-as-promised.js
+++ b/lib/chai-as-promised.js
@@ -87,7 +87,6 @@ module.exports = (chai, utils) => {
         } else if (message instanceof String) {
             return message;
         }
-        
         return reason;
     }
 


### PR DESCRIPTION
Checks that ```checkError.getConstructorName(reason)``` returns a String. If ```reason``` is neither an Error object nor a function, try calling ```checkError.getMessage(reason)```. If ```reason``` is error-like, it may have a message that is more useful than the description of ```reason```. 