### PR TITLE
feat: move to ESM-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
                     # See supported Node.js release schedule at https://github.com/nodejs/release#release-schedule
                 chai-version:
                     - "^4.0.0"
+                    - "^5.0.0"
 
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,43 +4,43 @@
 name: Node.js CI
 
 on:
-    push:
-        branches: master
-    pull_request:
-        branches: master
+  push:
+    branches: master
+  pull_request:
+    branches: master
 
 jobs:
-    lint:
-        runs-on: ubuntu-latest
+  lint:
+    runs-on: ubuntu-latest
 
-        steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-node@v4
-              with:
-                  node-version: latest
-            - run: npm ci
-            - run: npm run lint
-    build:
-        runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: latest
+      - run: npm ci
+      - run: npm run lint
+  build:
+    runs-on: ubuntu-latest
 
-        strategy:
-            matrix:
-                node-version:
-                    - 18      # to be removed 2025-04-30
-                    - 20      # to be removed 2026-04-30
-                    - latest
-                    # See supported Node.js release schedule at https://github.com/nodejs/release#release-schedule
-                chai-version:
-                    - "^4.0.0"
-                    - "^5.0.0"
+    strategy:
+      matrix:
+        node-version:
+          - 18 # to be removed 2025-04-30
+          - 20 # to be removed 2026-04-30
+          - latest
+          # See supported Node.js release schedule at https://github.com/nodejs/release#release-schedule
+        chai-version:
+          - '^4.0.0'
+          - '^5.0.0'
 
-        steps:
-            - uses: actions/checkout@v4
-            - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v4
-              with:
-                  node-version: ${{ matrix.node-version }}
-            - run: npm ci
-            - name: Install chai ${{ matrix.chai-version }}
-              run: npm install chai@${{ matrix.chai-version }}
-            - run: npm run test
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - name: Install chai ${{ matrix.chai-version }}
+        run: npm install chai@${{ matrix.chai-version }}
+      - run: npm run test

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -4,37 +4,37 @@
 name: Publish to npm
 
 on:
-    release:
-        types: [created]
+  release:
+    types: [created]
 
 jobs:
-    build:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-node@v4
-              with:
-                node-version: 22
-            - run: npm ci
-            - run: npm run lint
-            - run: npm test
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test
 
-    publish-npm:
-        needs: build
-        runs-on: ubuntu-latest
-        permissions:
-            id-token: write
-        steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-node@v4
-              with:
-                node-version: 22.x
-                registry-url: "https://registry.npmjs.org"
-                cache: "npm"
-            - run: npm ci
-            - run: npm version ${TAG_NAME} --git-tag-version=false
-              env:
-                TAG_NAME: ${{ github.ref_name }}
-            - run: npm publish --provenance --access public
-              env:
-                NODE_AUTH_TOKEN: ${{ secrets.npm_secret }}
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm version ${TAG_NAME} --git-tag-version=false
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.npm_secret }}

--- a/README.md
+++ b/README.md
@@ -107,11 +107,13 @@ return promise.then(null, null, progressSpy).then(function () {
 By default, the promises returned by Chai as Promised's assertions are regular Chai assertion objects, extended with a single `then` method derived from the input promise. To change this behavior, for instance to output a promise with more useful sugar methods such as are found in most promise libraries, you can override `chaiAsPromised.transferPromiseness`. Here's an example that transfer's Q's `finally` and `done` methods:
 
 ```js
-chaiAsPromised.transferPromiseness = function (assertion, promise) {
+import {setTransferPromiseness} from 'chai-as-promised';
+
+setTransferPromiseness(function (assertion, promise) {
     assertion.then = promise.then.bind(promise); // this is all you get by default
     assertion.finally = promise.finally.bind(promise);
     assertion.done = promise.done.bind(promise);
-};
+});
 ```
 
 ### Transforming Arguments to the Asserters
@@ -119,9 +121,11 @@ chaiAsPromised.transferPromiseness = function (assertion, promise) {
 Another advanced customization hook Chai as Promised allows is if you want to transform the arguments to the asserters, possibly asynchronously. Here is a toy example:
 
 ```js
-chaiAsPromised.transformAsserterArgs = function (args) {
+import {transformAsserterArgs} from 'chai-as-promised';
+
+setTransformAsserterArgs(function (args) {
     return args.map(function (x) { return x + 1; });
-}
+});
 
 Promise.resolve(2).should.eventually.equal(2); // will now fail!
 Promise.resolve(3).should.eventually.equal(2); // will now pass!
@@ -133,9 +137,9 @@ The transform can even be asynchronous, returning a promise for an array instead
 // This will normally fail, since within() only works on numbers.
 Promise.resolve(2).should.eventually.be.within(Promise.resolve(1), Promise.resolve(6));
 
-chaiAsPromised.transformAsserterArgs = function (args) {
+setTransformAsserterArgs(function (args) {
     return Promise.all(args);
-};
+});
 
 // But now it will pass, since we transformed the array of promises for numbers into
 // (a promise for) an array of numbers
@@ -213,15 +217,15 @@ This will pass any failures of the individual promise assertions up to the test 
 Do an `npm install chai-as-promised` to get up and running. Then:
 
 ```javascript
-var chai = require("chai");
-var chaiAsPromised = require("chai-as-promised");
+import * as chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 
 chai.use(chaiAsPromised);
 
 // Then either:
-var expect = chai.expect;
+const expect = chai.expect;
 // or:
-var assert = chai.assert;
+const assert = chai.assert;
 // or:
 chai.should();
 // according to your preference of assertion style
@@ -231,14 +235,12 @@ You can of course put this code in a common test fixture file; for an example us
 
 **Note when using other Chai plugins:** Chai as Promised finds all currently-registered asserters and promisifies them, at the time it is installed. Thus, you should install Chai as Promised _last_, after any other Chai plugins, if you expect their asserters to be promisified.
 
-### In the Browser
-
-To use Chai as Promised in environments that don't support Node.js-like CommonJS modules, you'll need to use a bundling tool like [browserify](http://browserify.org/). See also the note below about browser compatibility.
-
 ### Karma
 
 If you're using [Karma](https://karma-runner.github.io/), check out the accompanying [karma-chai-as-promised](https://github.com/vlkosinov/karma-chai-as-promised) plugin.
 
 ### Browser/Node Compatibility
 
-Chai as Promised requires Node v4+ or a browser with equivalent support for modern JavaScript syntax. If your browser doesn't support modern JavaScript syntax, you'll need to transpile it down using a tool like [Babel](http://babeljs.io/).
+Chai as Promised requires support for ES modules and modern JavaScript syntax.
+If your browser doesn't support this, you will need to transpile it down using
+a tool like [Babel](https://babeljs.io/).

--- a/lib/chai-as-promised.js
+++ b/lib/chai-as-promised.js
@@ -1,8 +1,8 @@
-'use strict';
-/* eslint-disable no-invalid-this */
-let checkError = require('check-error');
+import * as checkErrorDefault from 'check-error';
 
-module.exports = (chai, utils) => {
+let checkError = checkErrorDefault;
+
+export default function (chai, utils) {
   const Assertion = chai.Assertion;
   const assert = chai.assert;
   const proxify = utils.proxify;
@@ -120,7 +120,7 @@ module.exports = (chai, utils) => {
       }
     );
 
-    module.exports.transferPromiseness(this, derivedPromise);
+    transferPromiseness(this, derivedPromise);
     return this;
   });
 
@@ -147,7 +147,7 @@ module.exports = (chai, utils) => {
       }
     );
 
-    module.exports.transferPromiseness(this, derivedPromise);
+    transferPromiseness(this, derivedPromise);
     return this;
   });
 
@@ -258,7 +258,7 @@ module.exports = (chai, utils) => {
       }
     );
 
-    module.exports.transferPromiseness(this, derivedPromise);
+    transferPromiseness(this, derivedPromise);
     return this;
   });
 
@@ -346,7 +346,7 @@ module.exports = (chai, utils) => {
         assertion._obj = value;
         utils.flag(assertion, 'eventually', false);
 
-        return args ? module.exports.transformAsserterArgs(args) : args;
+        return args ? transformAsserterArgs(args) : args;
       })
       .then((newArgs) => {
         asserter.apply(assertion, newArgs);
@@ -357,7 +357,7 @@ module.exports = (chai, utils) => {
         return assertion._obj;
       });
 
-    module.exports.transferPromiseness(assertion, derivedPromise);
+    transferPromiseness(assertion, derivedPromise);
     return assertion;
   }
 
@@ -413,10 +413,38 @@ module.exports = (chai, utils) => {
       return returnedPromise;
     };
   });
-};
+}
 
-module.exports.transferPromiseness = (assertion, promise) => {
+function defaultTransferPromiseness(assertion, promise) {
   assertion.then = promise.then.bind(promise);
-};
+}
 
-module.exports.transformAsserterArgs = (values) => values;
+function defaultTransformAsserterArgs(values) {
+  return values;
+}
+
+let customTransferPromiseness;
+let customTransformAsserterArgs;
+
+export function setTransferPromiseness(fn) {
+  customTransferPromiseness = fn || defaultTransferPromiseness;
+}
+
+export function setTransformAsserterArgs(fn) {
+  customTransformAsserterArgs = fn || defaultTransformAsserterArgs;
+}
+
+export function transferPromiseness(assertion, promise) {
+  if (customTransferPromiseness) {
+    customTransferPromiseness(assertion, promise);
+  } else {
+    defaultTransferPromiseness(assertion, promise);
+  }
+}
+
+export function transformAsserterArgs(values) {
+  if (customTransformAsserterArgs) {
+    return customTransformAsserterArgs(values);
+  }
+  return defaultTransformAsserterArgs(values);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "7.1.2",
       "license": "WTFPL",
       "dependencies": {
-        "check-error": "^1.0.2"
+        "check-error": "^2.0.0"
       },
       "devDependencies": {
         "c8": "^9.1.0",
-        "chai": "^4.4.1",
+        "chai": "^5.1.0",
         "eslint": "^8.57.0",
         "mocha": "^10.4.0",
         "prettier": "^3.2.5"
@@ -300,12 +300,12 @@
       }
     },
     "node_modules/assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
       "engines": {
-        "node": "*"
+        "node": ">=12"
       }
     },
     "node_modules/balanced-match": {
@@ -421,21 +421,19 @@
       }
     },
     "node_modules/chai": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
-      "integrity": "sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.1.0.tgz",
+      "integrity": "sha512-kDZ7MZyM6Q1DhR9jy7dalKohXQ2yrlXkk59CR52aRKxJrobmlBNqnFQxX9xOX8w+4mz8SYlKJa/7D7ddltFXCw==",
       "dev": true,
       "dependencies": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.3",
-        "deep-eql": "^4.1.3",
-        "get-func-name": "^2.0.2",
-        "loupe": "^2.3.6",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.0.8"
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.0.0",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=12"
       }
     },
     "node_modules/chalk": {
@@ -455,14 +453,11 @@
       }
     },
     "node_modules/check-error": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
-      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
-      "dependencies": {
-        "get-func-name": "^2.0.2"
-      },
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.0.0.tgz",
+      "integrity": "sha512-tjLAOBHKVxtPoHe/SA7kNOMvhCRdCJ3vETdeY0RuAc9popf+hyaSV6ZEg9hr4cpWF7jmo/JSWEnLDrnijS9Tog==",
       "engines": {
-        "node": "*"
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -581,13 +576,10 @@
       }
     },
     "node_modules/deep-eql": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
-      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.1.tgz",
+      "integrity": "sha512-nwQCf6ne2gez3o1MxWifqkciwt0zhl0LO1/UwVu4uMBuPmflWM4oQ70XMqHqnBJA+nhzncaqL9HVL6KkHJ28lw==",
       "dev": true,
-      "dependencies": {
-        "type-detect": "^4.0.0"
-      },
       "engines": {
         "node": ">=6"
       }
@@ -1002,6 +994,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
       "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -1332,9 +1325,9 @@
       }
     },
     "node_modules/loupe": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
-      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.0.tgz",
+      "integrity": "sha512-qKl+FrLXUhFuHUoDJG7f8P8gEMHq9NFS0c6ghXG1J0rldmZFQZoNVv/vyirE9qwCIhWZDsvEFd1sbFu3GvRQFg==",
       "dev": true,
       "dependencies": {
         "get-func-name": "^2.0.1"
@@ -1621,12 +1614,12 @@
       }
     },
     "node_modules/pathval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
+      "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
       "dev": true,
       "engines": {
-        "node": "*"
+        "node": ">= 14.16"
       }
     },
     "node_modules/picomatch": {
@@ -1978,15 +1971,6 @@
       },
       "engines": {
         "node": ">=8.0"
-      }
-    },
-    "node_modules/type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/type-fest": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "chai-as-promised",
+  "type": "module",
   "description": "Extends Chai with assertions about promises.",
   "keywords": [
     "chai",
@@ -16,6 +17,9 @@
   "license": "WTFPL",
   "repository": "domenic/chai-as-promised",
   "main": "./lib/chai-as-promised.js",
+  "exports": {
+    ".": "./lib/chai-as-promised.js"
+  },
   "files": [
     "lib"
   ],
@@ -25,14 +29,14 @@
     "format": "prettier --write lib test"
   },
   "dependencies": {
-    "check-error": "^1.0.2"
+    "check-error": "^2.0.0"
   },
   "peerDependencies": {
     "chai": ">= 2.1.2 < 6"
   },
   "devDependencies": {
     "c8": "^9.1.0",
-    "chai": "^4.4.1",
+    "chai": "^5.1.0",
     "eslint": "^8.57.0",
     "mocha": "^10.4.0",
     "prettier": "^3.2.5"

--- a/test/assert-eventually.js
+++ b/test/assert-eventually.js
@@ -1,9 +1,6 @@
-'use strict';
-require('./support/setup.js');
-const shouldPass = require('./support/common.js').shouldPass;
-const shouldFail = require('./support/common.js').shouldFail;
-const assert = require('chai').assert;
-const expect = require('chai').expect;
+import './support/setup.js';
+import {shouldPass, shouldFail} from './support/common.js';
+import {assert, expect} from 'chai';
 
 describe('Assert interface with eventually extender:', () => {
   let promise = null;

--- a/test/assert-promise-specific.js
+++ b/test/assert-promise-specific.js
@@ -1,8 +1,6 @@
-'use strict';
-require('./support/setup.js');
-const shouldPass = require('./support/common.js').shouldPass;
-const shouldFail = require('./support/common.js').shouldFail;
-const assert = require('chai').assert;
+import './support/setup.js';
+import {shouldPass, shouldFail} from './support/common.js';
+import {assert} from 'chai';
 
 describe('Assert interface:', () => {
   let promise = null;

--- a/test/chainable-methods-compat.js
+++ b/test/chainable-methods-compat.js
@@ -1,7 +1,7 @@
-'use strict';
-const chai = require('chai');
-const chaiAsPromised = require('..');
-const expect = chai.expect;
+import chaiAsPromised from '../lib/chai-as-promised.js';
+import * as chai from 'chai';
+
+const {expect} = chai;
 
 function newMethod() {
   // Do nothing

--- a/test/configurable-asserter-args.js
+++ b/test/configurable-asserter-args.js
@@ -1,15 +1,16 @@
-'use strict';
-require('./support/setup.js');
-const chaiAsPromised = require('..');
-const originalTransformAsserterArgs = require('..').transformAsserterArgs;
+import './support/setup.js';
+import {
+  default as chaiAsPromised,
+  setTransformAsserterArgs
+} from '../lib/chai-as-promised.js';
 
 describe('Configuring the way in which asserter arguments are transformed', () => {
   beforeEach(() => {
-    chaiAsPromised.transformAsserterArgs = Promise.all.bind(Promise);
+    setTransformAsserterArgs(Promise.all.bind(Promise));
   });
 
   afterEach(() => {
-    chaiAsPromised.transformAsserterArgs = originalTransformAsserterArgs;
+    setTransformAsserterArgs(null);
   });
 
   it('should override transformAsserterArgs and allow to compare promises', () => {
@@ -38,9 +39,9 @@ describe('Configuring the way in which asserter arguments are transformed', () =
   });
 
   it('should transform asserter args', () => {
-    chaiAsPromised.transformAsserterArgs = (args) => {
+    setTransformAsserterArgs((args) => {
       return Array.from(args).map((x) => x + 1);
-    };
+    });
 
     return Promise.resolve(3).should.eventually.equal(2);
   });

--- a/test/configurable-promiseness-transfer.js
+++ b/test/configurable-promiseness-transfer.js
@@ -1,18 +1,16 @@
-'use strict';
-require('./support/setup.js');
-const chaiAsPromised = require('..');
-const originalTransferPromiseness = require('..').transferPromiseness;
+import './support/setup.js';
+import {setTransferPromiseness} from '../lib/chai-as-promised.js';
 
 describe('Configuring the way in which promise-ness is transferred', () => {
   afterEach(() => {
-    chaiAsPromised.transferPromiseness = originalTransferPromiseness;
+    setTransferPromiseness(null);
   });
 
   it('should return a promise with the custom modifications applied', () => {
-    chaiAsPromised.transferPromiseness = (assertion, promise) => {
+    setTransferPromiseness((assertion, promise) => {
       assertion.then = promise.then.bind(promise);
       assertion.isCustomized = true;
-    };
+    });
 
     const promise = Promise.resolve('1234');
     const assertion = promise.should.become('1234');

--- a/test/custom-messages.js
+++ b/test/custom-messages.js
@@ -1,7 +1,5 @@
-'use strict';
-require('./support/setup.js');
-const shouldPass = require('./support/common.js').shouldPass;
-const shouldFail = require('./support/common.js').shouldFail;
+import './support/setup.js';
+import {shouldPass, shouldFail} from './support/common.js';
 
 describe('Custom messages', () => {
   let promise = null;

--- a/test/proxy-guard.js
+++ b/test/proxy-guard.js
@@ -1,6 +1,5 @@
-'use strict';
-const chai = require('chai');
-const chaiAsPromised = require('..');
+import chaiAsPromised from '../lib/chai-as-promised.js';
+import * as chai from 'chai';
 
 chai.should();
 chai.use(chaiAsPromised);

--- a/test/should-eventually.js
+++ b/test/should-eventually.js
@@ -1,7 +1,5 @@
-'use strict';
-require('./support/setup.js');
-const shouldPass = require('./support/common.js').shouldPass;
-const shouldFail = require('./support/common.js').shouldFail;
+import './support/setup.js';
+import {shouldPass, shouldFail} from './support/common.js';
 
 describe('Fulfillment value assertions:', () => {
   let promise = null;

--- a/test/should-promise-specific.js
+++ b/test/should-promise-specific.js
@@ -1,8 +1,6 @@
-'use strict';
-require('./support/setup.js');
-const shouldPass = require('./support/common.js').shouldPass;
-const shouldFail = require('./support/common.js').shouldFail;
-const expect = require('chai').expect;
+import './support/setup.js';
+import {expect} from 'chai';
+import {shouldPass, shouldFail} from './support/common.js';
 
 describe('Promise-specific extensions:', () => {
   let promise = null;

--- a/test/support/common.js
+++ b/test/support/common.js
@@ -1,6 +1,4 @@
-'use strict';
-
-exports.shouldPass = (promiseProducer) => {
+export function shouldPass(promiseProducer) {
   it('should return a fulfilled promise', (done) => {
     promiseProducer().then(
       () => done(),
@@ -12,9 +10,9 @@ exports.shouldPass = (promiseProducer) => {
         )
     );
   });
-};
+}
 
-exports.shouldFail = (options) => {
+export function shouldFail(options) {
   const promiseProducer = options.op;
   const desiredMessageSubstring = options.message;
   const nonDesiredMessageSubstring = options.notMessage;
@@ -61,4 +59,4 @@ exports.shouldFail = (options) => {
       )
       .then(done, done);
   });
-};
+}

--- a/test/support/setup.js
+++ b/test/support/setup.js
@@ -1,5 +1,5 @@
-const chai = require('chai');
-const chaiAsPromised = require('../../lib/chai-as-promised.js');
+import * as chai from 'chai';
+import chaiAsPromised from '../../lib/chai-as-promised.js';
 
 chai.should();
 chai.use(chaiAsPromised);


### PR DESCRIPTION
Migrates to an ESM-only package structure.

The module must now be imported like so:

```ts
import chaiAsPromised from 'chai-as-promised';
import * as chai from 'chai';

chai.use(chaiAsPromised);
```

Depends on #286 