### PR TITLE
fix: raise a nicer error when non-object errors are matched

### DIFF
--- a/lib/chai-as-promised.js
+++ b/lib/chai-as-promised.js
@@ -215,7 +215,10 @@ module.exports = (chai, utils) => {
             : checkError.compatibleConstructor(reason, errorLike));
 
         const errMsgMatcherCompatible =
-          errMsgMatcher && checkError.compatibleMessage(reason, errMsgMatcher);
+          errMsgMatcher === reason ||
+          (errMsgMatcher &&
+            reason &&
+            checkError.compatibleMessage(reason, errMsgMatcher));
 
         const reasonName = getReasonName(reason);
 

--- a/test/assert-promise-specific.js
+++ b/test/assert-promise-specific.js
@@ -291,5 +291,20 @@ describe('Assert interface:', () => {
         });
       });
     });
+
+    describe('with undefined error', () => {
+      beforeEach(() => {
+        promise = Promise.reject();
+      });
+
+      describe('.isRejected(promise)', () => {
+        shouldPass(() => assert.isRejected(promise));
+        shouldPass(() => assert.isRejected(promise, undefined));
+        shouldFail({
+          op: () => assert.isRejected(promise, 'Error'),
+          message: "to be rejected with an error including 'Error' but got ''"
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
When a promise is rejected, we currently incorrectly assume the rejection reason is an object consumable by check-error (i.e. an `Error` or similar).

This change basically checks strict equality on the matcher and the thrown error first (such that `rejectedWith(undefined)` would work). It then falls back to the original logic only if both the matcher and the reason are truthy.

Fixes #263